### PR TITLE
[GT de Serviços] PSV-354 - Automatic Payments - v2.2.0-rc.1: Proposta para esclarecer em qual estado o consentimento permite sua edição

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -316,7 +316,7 @@ paths:
 
         2 - Informações sobre a edição: 
         - Os campos que são passíveis de edição e suas regras podem ser encontrados através do [link](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/628195665);
-        - A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”) e que encontrem-se autorizados (´data.status´ == ´AUTHORISED´);
+        - A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”) e que encontrem-se autorizados (`data.status == AUTHORISED`);
         - O envio do item "/data/creditors/name" atualizará o nome do recebedor em todos os elementos do array.
         - Caso consentimento seja de valor fixo (campo “/data/recurringConfiguration/automatic/fixedAmount” preenchido) não é permitida a edição do campo “/data/recurringConfiguration/automatic/maximumVariableAmount”.
         - Caso o recebedor tenha definido um piso para o limite a ser estipulado pelo pagador (campo “/data/recurringConfiguration/automatic/minimumVariableAmount” preenchido), o valor máximo de limite por transação definido pelo usuário pagador (campo “/data/recurringConfiguration/automatic/maximumVariableAmount”) não pode ser menor que o valor estipulado pelo recebedor.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -184,7 +184,7 @@ info:
     Não é permitido ao usuário pagador o cancelamento de uma nova tentativa de pagamento, realizada pelo recebedor, quando autorizado no consentimento (campo “/data/recurringConfiguration/automatic/isRetryAccepted” como “True”) pelo usuário pagador ou quando o Iniciador precisar enviar um novo endToEndId. 
     Aplica-se tanto para a tentativa intradia quanto para a tentativa em dias subsequentes. É permitido ao recebedor o cancelamento das novas tentativas em dias subsequentes. Aplicam-se as regras de cancelamento da tentativa original, conforme previsto na descrição do endpoint PATCH /pix/recurringPayments Pagamentos que são novas tentativas, intradia ou em dias subsequentes, podem ser identificados pela presença do campo “/data/originalRecurringPaymentId” no recurso. 
   
-  version: 2.1.0
+  version: 2.2.0-rc.1
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -316,7 +316,7 @@ paths:
 
         2 - Informações sobre a edição: 
         - Os campos que são passíveis de edição e suas regras podem ser encontrados através do [link](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/628195665);
-        - A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”);
+        - A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”) e que encontrem-se autorizados (´data.status´ == ´AUTHORISED´);
         - O envio do item "/data/creditors/name" atualizará o nome do recebedor em todos os elementos do array.
         - Caso consentimento seja de valor fixo (campo “/data/recurringConfiguration/automatic/fixedAmount” preenchido) não é permitida a edição do campo “/data/recurringConfiguration/automatic/maximumVariableAmount”.
         - Caso o recebedor tenha definido um piso para o limite a ser estipulado pelo pagador (campo “/data/recurringConfiguration/automatic/minimumVariableAmount” preenchido), o valor máximo de limite por transação definido pelo usuário pagador (campo “/data/recurringConfiguration/automatic/maximumVariableAmount”) não pode ser menor que o valor estipulado pelo recebedor.


### PR DESCRIPTION
### Contexto
Em definição

### Descrição
Na descrição do endpoint PATCH /recurring-consents/{recurringConsentId}, no item 2, alterar o seguinte item:

- DE: A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”);

- PARA: A edição é possível apenas em casos de consentimento para Pix Automático (“automatic” escolhido no oneOf do objeto “recurringConfiguration”) e que encontrem-se autorizados (´data.status´ == ´AUTHORISED´)
