### PR TITLE
[GT de Serviços] PSV-355 - Automatic Payments - v2.2.0-rc.1: Pix Automático – Proposta para adicionar um novo endpoint para solicitação de novas tentativas de pagamento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -479,6 +479,65 @@ paths:
       security:
         - OAuth2ClientCredentials:
             - recurring-payments
+  '/pix/recurring-payments/{originalRecurringPaymentId}/retry':
+    post:
+      tags:
+        - Recurring Payments
+      summary: Cria nova tentativa de pagamento para o Pix Automático.
+      operationId: automaticPaymentsPostPixRecurringPaymentsRetry
+      description: |
+        Método para a criação de novas tentativas de pagamentos associadas uma tentativa original que falhou. Exclusivo para o Pix Automático.  
+        O recurso criado que representa a nova tentativa deve ser consultado através do endpoint atual de consulta de pagamentos (GET /pix/recurring-payments/{recurringPaymentId}).  
+        Na consulta do recurso criado neste método, que representa essa nova tentativa, a detentora ficará responsável por retornar os campos que não foram alterados entre as tentativas.
+        As regras de novas tentativas podem ser encontradas na versão mais recente da documentação da API, presente na área do desenvolvedor
+      parameters:
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/pathOriginalRecurringPaymentId'
+        - $ref: '#/components/parameters/XIdempotencyKey'
+      requestBody:
+        content:
+          application/jwt:
+            schema:
+              $ref: '#/components/schemas/CreateRecurringRetryPixPayment'
+        description: Payload para nova tentativa de liquidação do pagamento automático.
+        required: true
+      responses:
+        '201':
+          $ref: '#/components/responses/201RecurringRetryPaymentsIdPost'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityPixRetryRecurringPayment'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeoutWithAdditionalProperties'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
+        default:
+          description: Erro inesperado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+      security:
+        - OAuth2ClientCredentials:
+            - recurring-payments
+  
   '/pix/recurring-payments/{recurringPaymentId}':
     get:
       tags:
@@ -530,16 +589,6 @@ paths:
       operationId: automaticPaymentsPatchPixRecurringPaymentsPaymentId
       description: |
         Esse endpoint deve ser usado para cancelar as transações que estejam em uma das seguintes situações: 
-        Agendada com sucesso (SCHD), retida para análise (PDNG). Caso a requisição seja bem sucedida, a transação vai para a situação CANC. 
-        
-        Caso o status do pagamento seja diferente de SCHD/PDNG ou alguma outra regra de negócio impeça o cancelamento, a requisição PATCH retorna 
-        HTTP Status 422 com o code PAGAMENTO_NAO_PERMITE_CANCELAMENTO. 
-        
-        Caso receba um 422, a iniciadora deve fazer uma requisição GET no pagamento para verificar a situação atual dele, bem como detalhes associados. 
-
-        [Restrição] Para o Pix automático (“recurringConfiguration” igual a “automatic”) tanto o recebedor quanto o pagador poderão realizar o cancelamento, 
-        sendo permitido ao recebedor a solicitação de cancelamento até as 22:00 (Horário de Brasília) e ao pagador até as 23:59 (Horário de Brasília) do dia anterior à data de efetivação do pagamento, 
-        exceto para os casos de novas tentativas em dias subsequentes, onde apenas o recebedor pode cancelar, também até as 22:00h.
       parameters:
         - $ref: '#/components/parameters/Authorization'
         - $ref: '#/components/parameters/xCustomerUserAgent'
@@ -732,6 +781,84 @@ components:
                   - FALTAM_SINAIS_OBRIGATORIOS_PLATAFORMA: Os sinais obrigatórios para a plataforma do usuário não foram enviados em sua totalidade.
                   - PARAMETRO_INVALIDO: Os parâmetros informados não obedecem a formatação especificada.
                   - PARAMETRO_NAO_INFORMADO: Algum ou todos os campos obrigatórios não foram informados.
+        meta:
+          $ref: '#/components/schemas/Meta'
+    422ResponseErrorCreateRetryPixRecurringPayment:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          maxItems: 9
+          items:
+            type: object
+            required:
+              - code
+              - title
+              - detail
+            properties:
+              code:
+                type: string
+                enum:
+                  - ERRO_IDEMPOTENCIA
+                  - CONSENTIMENTO_INVALIDO
+                  - PARAMETRO_NAO_INFORMADO
+                  - PARAMETRO_INVALIDO
+                  - PAGAMENTO_RECUSADO_DETENTORA
+                  - LIMITE_TENTATIVAS_EXCEDIDO
+                  - FORA_PRAZO_PERMITIDO
+                  - FALHA_INFRAESTRUTURA_DETENTORA
+                  - DETALHE_TENTATIVA_INVALIDO
+                  - NAO_PERMITIDO
+                example: LIMITE_TENTATIVAS_EXCEDIDO
+                description: |
+                  Códigos de erros previstos na criação da iniciação de pagamento:
+                  - ERRO_IDEMPOTENCIA: Erro idempotência.
+                  - CONSENTIMENTO_INVALIDO: Consentimento inválido (em status final).
+                  - PARAMETRO_NAO_INFORMADO: Parâmetro não informado.
+                  - PARAMETRO_INVALIDO: Parâmetro inválido.
+                  - PAGAMENTO_RECUSADO_DETENTORA: Pagamento recusado pela detentora de conta.
+                  - FALHA_INFRAESTRUTURA_DETENTORA - Ocorreu uma falha de infraestrutura interna na detentora durante o processamento do pagamento.
+                  - LIMITE_TENTATIVAS_EXCEDIDO: O limite de tentativas para liquidação do pagamento permitidas pelo arranjo foi excedido.
+                  - FORA_PRAZO_PERMITIDO: O horário ou período da requisição não permite o agendamento pelo detentor.
+                  - DETALHE_TENTATIVA_INVALIDO: O parâmetro [nome_do(s)_campo(s)] inseridos para a nova tentativa de pagamento não condizem com o pagamento original que falhou e não são permitidos na nova tentativa de pagamento.
+                  - NAO_PERMITIDO: Valida se o valor do originalRecurringPaymentId aponta para um pagamento de Pix Automático
+              title:
+                type: string
+                maxLength: 255
+                pattern: '[\w\W\s]*'
+                example: Saldo insuficiente.
+                description: |
+                  Título específico do erro reportado, de acordo com o código enviado:
+                  - ERRO_IDEMPOTENCIA: Erro idempotência.
+                  - CONSENTIMENTO_INVALIDO: Consentimento inválido (em status final).
+                  - PARAMETRO_NAO_INFORMADO: Parâmetro não informado.
+                  - PARAMETRO_INVALIDO: Parâmetro inválido.
+                  - PAGAMENTO_RECUSADO_DETENTORA: Pagamento recusado pela detentora de conta.
+                  - FALHA_INFRAESTRUTURA_DETENTORA - Ocorreu uma falha de infraestrutura interna na detentora durante o processamento do pagamento.
+                  - LIMITE_TENTATIVAS_EXCEDIDO: Limite de tentativas excedido.
+                  - FORA_PRAZO_PERMITIDO: Tentativa fora do prazo.
+                  - DETALHE_TENTATIVA_INVALIDO: Nova tentativa inválida
+                  - NAO_PERMITIDO: Valida se o valor do originalRecurringPaymentId aponta para um pagamento de Pix Automático
+              detail:
+                type: string
+                maxLength: 2048
+                pattern: '[\w\W\s]*'
+                example: A conta selecionada não possui saldo suficiente para realizar o pagamento.
+                description: |
+                  Descrição específica do erro de acordo com o código reportado:
+                  - ERRO_IDEMPOTENCIA: Erro idempotência.
+                  - CONSENTIMENTO_INVALIDO: Consentimento inválido (em status final).
+                  - PARAMETRO_NAO_INFORMADO: Parâmetro não informado.
+                  - PARAMETRO_INVALIDO: Parâmetro inválido.
+                  - PAGAMENTO_RECUSADO_DETENTORA: Pagamento recusado pela detentora de conta.
+                  - FALHA_INFRAESTRUTURA_DETENTORA - Ocorreu uma falha de infraestrutura interna na detentora durante o processamento do pagamento.
+                  - LIMITE_TENTATIVAS_EXCEDIDO: O limite de tentativas para liquidação do pagamento permitidas pelo arranjo foi excedido.
+                  - FORA_PRAZO_PERMITIDO: O horário ou período da requisição não permite o agendamento pelo detentor.
+                  - DETALHE_TENTATIVA_INVALIDO: O parâmetro [nome_do(s)_campo(s)] inseridos para a nova tentativa de pagamento não condizem com o pagamento original que falhou e não são permitidos na nova tentativa de pagamento.
+                  - NAO_PERMITIDO: Valida se o valor do originalRecurringPaymentId aponta para um pagamento de Pix Automático
         meta:
           $ref: '#/components/schemas/Meta'
     422ResponseErrorCreatePixRecurringPayment:
@@ -1015,6 +1142,13 @@ components:
                 - $ref: '#/components/schemas/AutomaticRequest'
                 - $ref: '#/components/schemas/SweepingRequest'
                 - $ref: '#/components/schemas/Vrp'
+    CreateRecurringRetryPixPayment:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/CreateRecurringRetryPixPaymentData'
     CreateRecurringPixPayment:
       type: object
       required:
@@ -1022,6 +1156,22 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/CreateRecurringPixPaymentData'
+    CreateRecurringRetryPixPaymentData:
+      type: object
+      description: Objeto contendo dados da nova tentativa de pagamento.
+      required:
+        - endToEndId
+        - date
+      properties:
+        endToEndId:
+          $ref: '#/components/schemas/EndToEndIdPost'
+        date:
+          type: string
+          format: date
+          maxLength: 10
+          pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
+          example: '2021-01-01'
+          description: Data em que o pagamento será realizado. Uma string com a utilização de timezone UTC-3 (UTC time format).
     CreateRecurringPixPaymentData:
       type: object
       description: Objeto contendo dados do pagamento e do recebedor (creditor).
@@ -3999,6 +4149,19 @@ components:
             - $ref: '#/components/schemas/ConsentEdition'
             - $ref: '#/components/schemas/ConsentRevocation'
             - $ref: '#/components/schemas/ConsentRejection'
+    ResponseRecurringRetryPaymentsIdPost:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseRecurringRetryPaymentsPostData'
+        links:
+          $ref: '#/components/schemas/LinkSingle'
+        meta:
+          $ref: '#/components/schemas/Meta'
     ResponseRecurringPaymentsIdPost:
       type: object
       required:
@@ -4196,6 +4359,37 @@ components:
                   - Trimestral: "Q3-2024"
                   - Semestral: "S2-2024"
                   - Anual: "Y2024"
+    ResponseRecurringRetryPaymentsPostData:
+      type: object
+      required:
+        - recurringPaymentId
+        - endToEndId
+        - date
+        - status
+        - originalRecurringPaymentId
+      properties:
+        recurringPaymentId:
+          type: string
+          minLength: 1
+          maxLength: 100
+          pattern: '^[a-zA-Z0-9][a-zA-Z0-9\-]{0,99}$'
+          example: TXpRMU9UQTROMWhZV2xSU1FUazJSMDl
+          description: |
+            Código ou identificador único informado pela instituição detentora da conta para representar a iniciação de pagamento. O `recurringPaymentId` deve ser diferente do `endToEndId`. 
+            Este é o identificador que deverá ser utilizado na consulta ao status da iniciação de pagamento efetuada.
+        endToEndId:
+          $ref: '#/components/schemas/EndToEndId'
+        date:
+          type: string
+          maxLength: 10
+          pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
+          example: '2023-10-10'
+          description: Data em que o pagamento será realizado. Uma string com a utilização de timezone UTC-3 (UTC time format).
+        status:
+          $ref: '#/components/schemas/EnumPaymentStatusType'
+        originalRecurringPaymentId:
+          $ref: '#/components/schemas/originalRecurringPaymentId'
+
     ResponseRecurringPaymentsPostData:
       type: object
       required:
@@ -4809,6 +5003,18 @@ components:
       pattern: '^\d+\.\d+\.\d+$'
       example: 1.0.0
   parameters:
+    pathOriginalRecurringPaymentId:
+      name: originalRecurringPaymentId
+      in: path
+      description: |
+        Campo que contém o identificador da tentativa original de pagamento que falhou. Código ou identificador único criado pela instituição detentora da conta para representar a iniciação de pagamento.  
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 100
+        pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-]{0,99}$
+        example: TXpRMU9UQTROMWhZV2xSU1FUazJSMDl
     recurringConsentId:
       name: recurringConsentId
       in: query
@@ -4881,8 +5087,8 @@ components:
       name: originalRecurringPaymentId
       in: query
       description: |
-        Campo que contém o código ou o identificador da tentativa original de pagamento que falhou. 
-        Código ou identificador único criado pela instituição detentora da conta para representar a iniciação de pagamento. 
+        Campo que contém o código ou o identificador da tentativa original de pagamento que falhou.  
+        Código ou identificador único criado pela instituição detentora da conta para representar a iniciação de pagamento.  
         Caso informado, devem ser retornados todos os pagamentos associados ao identificador informado, sendo eles o pagamento original (dono do identificador) e as novas tentativas que enviaram o identificador na sua requisição, indicando que representam nova tentativa.
       required: false
       schema:
@@ -5068,6 +5274,25 @@ components:
       headers:
         x-fapi-interaction-id:
           $ref: '#/components/headers/XFapiInteractionIdError'
+    UnprocessableEntityPixRetryRecurringPayment:
+      description: 'A solicitação foi bem formada, mas não pôde ser processada devido à lógica de negócios específica da solicitação.'
+      content:
+        application/jwt:
+          schema:
+            $ref: '#/components/schemas/422ResponseErrorCreateRetryPixRecurringPayment'
+          examples:
+            limiteTentativasExcedido:
+              summary: Limite de tentativas excedido
+              value:
+                errors:
+                  - code: LIMITE_TENTATIVAS_EXCEDIDO
+                    title: Limite de tentativas excedido
+                    detail: O limite de tentativas para liquidação do pagamento permitidas pelo arranjo foi excedido.
+                meta:
+                  requestDateTime: '2021-05-21T08:30:00Z'
+      headers:
+        x-fapi-interaction-id:
+          $ref: '#/components/headers/XFapiInteractionId'
     UnprocessableEntityPixRecurringPayment:
       description: 'A solicitação foi bem formada, mas não pôde ser processada devido à lógica de negócios específica da solicitação.'
       content:
@@ -5210,3 +5435,14 @@ components:
         application/jwt:
           schema:
             $ref: '#/components/schemas/ResponseRecurringPaymentsIdPost'
+    201RecurringRetryPaymentsIdPost:
+      description: Dados de iniciação de pagamento Pix obtidos com sucesso.
+      headers:
+        x-fapi-interaction-id:
+          $ref: '#/components/headers/XFapiInteractionId'
+        x-v:
+          $ref: '#/components/headers/X-V'
+      content:
+        application/jwt:
+          schema:
+            $ref: '#/components/schemas/ResponseRecurringRetryPaymentsIdPost'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -588,7 +588,17 @@ paths:
       summary: Cancelamento de solicitação de pagamento automático.
       operationId: automaticPaymentsPatchPixRecurringPaymentsPaymentId
       description: |
-        Esse endpoint deve ser usado para cancelar as transações que estejam em uma das seguintes situações: 
+        Esse endpoint deve ser usado para cancelar as transações que estejam em uma das seguintes situações:  
+        Agendada com sucesso (SCHD), retida para análise (PDNG). Caso a requisição seja bem sucedida, a transação vai para a situação CANC. 
+        
+        Caso o status do pagamento seja diferente de SCHD/PDNG ou alguma outra regra de negócio impeça o cancelamento, a requisição PATCH retorna 
+        HTTP Status 422 com o code PAGAMENTO_NAO_PERMITE_CANCELAMENTO. 
+        
+        Caso receba um 422, a iniciadora deve fazer uma requisição GET no pagamento para verificar a situação atual dele, bem como detalhes associados. 
+
+        [Restrição] Para o Pix automático (“recurringConfiguration” igual a “automatic”) tanto o recebedor quanto o pagador poderão realizar o cancelamento, 
+        sendo permitido ao recebedor a solicitação de cancelamento até as 22:00 (Horário de Brasília) e ao pagador até as 23:59 (Horário de Brasília) do dia anterior à data de efetivação do pagamento, 
+        exceto para os casos de novas tentativas em dias subsequentes, onde apenas o recebedor pode cancelar, também até as 22:00h.
       parameters:
         - $ref: '#/components/parameters/Authorization'
         - $ref: '#/components/parameters/xCustomerUserAgent'


### PR DESCRIPTION
### Contexto
▪ Foi publicada pelo Banco Central do Brasil a Instrução Normativa nº 614, que atualiza algumas das regras de funcionamento do Pix Automático no arranjo
▪ Em decorrência dessas atualizações, será necessário realizar ajustes na API Pagamentos automáticos referentes ao produto Pix Automático
▪ Esta proposta tem como objetivo tratar especificamente a alteração prevista no Art. 7º, §13, que determina que não deve haver a necessidade de verificação de autorização para novas tentativas de pagamento enviadas pelo ITP ao PSP do pagador

### Descrição
Criar um novo endpoint na API Pagamentos automáticos:
– Método: POST
– Path: /pix/recurring-payments/{originalRecurringPaymentId }/retry
– Descrição: Método para a criação de novas tentativas de pagamentos associadas uma tentativa original que falhou.
Exclusivo para o Pix Automático. As regras de novas tentativas podem ser encontradas na versão mais recente da
documentação da API, presente na área do desenvolvedor
– Request Headers:
▫ x-fapi-interaction-id;
▫ Authorization;
▫ x-fapi-auth-date;
▫ x-fapi-customer-ip-address;
▫ x-customer-user-agent;
▫ x-idempotency-key
– Security:
▫ OAuth2ClientCredentials
- Scope: recurring-payments
– Media type:
▫ application/jwt
– RequestBody:
▫ data
- endToEndId
- date
- Responses:
▫ Sucesso: HTTP 201
- Response Body:
- data
- recurringPaymentId
- status
- date
- endToEndId
- originalRecurringPaymentId
▫ Errors:
- HTTP Gerais: 400, 401, 403, 404, 405, 406, 500, 504, 529
- Erros de negócio, HTTP 422 – Códigos: (code, title, detail)
- LIMITE_TENTATIVAS_EXCEDIDO – Quando a quantidade de tentativas excedeu o limite estipulado;
- FORA_PRAZO_PERMITIDO – Quando a tentativa ocorre após o prazo permitido para a periodicidade definida;
- DETALHE_TENTATIVA_INVALIDO – Valida se os parâmetros informados condizem com a tentativa original de pagamento;
- FALHA_INFRAESTRUTURA_DETENTORA - Ocorreu uma falha de infraestrutura interna na detentora durante o processamento do pagamento;
- PAGAMENTO_RECUSADO_DETENTORA - Valida se pagamento foi recusado pela detentora, com a descrição do motivo de recusa.
- NAO_PERMITIDO: Valida se o valor do originalRecurringPaymentId aponta para um pagamento de Pix Automático