### PR TITLE
[GT de Serviços] PSV-359 - Automatic Payments - v2.2.0-rc.1: API Pagamentos Automáticos – Proposta para remover do consentimento os erros de validação de saldo e valores acima do limite

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -82,9 +82,7 @@ info:
         &ensp;2.1.3 Rejeitado pelo usuário: O usuário explicitamente rejeitou a autorização do consentimento (REJEITADO_USUARIO);  
         &ensp;2.1.4 Mesma conta origem/destino: A conta indicada pelo usuário para recebimento é a mesma selecionada para o pagamento (CONTAS_ORIGEM_DESTINO_IGUAIS);  
         &ensp;2.1.5 Tipo de conta inválida: A conta indicada não permite operações de pagamento (CONTA_NAO_PERMITE_PAGAMENTO);  
-        &ensp;2.1.6 Saldo do usuário: Valida se a conta selecionada possui saldo suficiente para realizar o pagamento (SALDO_INSUFICIENTE);  
-        &ensp;2.1.7 Limites da transação: Valida se o valor ultrapassa o limite estabelecido [na instituição/no arranjo/outro] para permitir a realização de transações pelo cliente (VALOR_ACIMA_LIMITE);  
-        &ensp;2.1.8 Autenticação divergente: O usuário autenticado no ambiente da detentora não é o mesmo usuário autenticado no ambiente da iniciadora e que criou o consentimento. (AUTENTICACAO _DIVERGENTE);  
+        &ensp;2.1.6 Autenticação divergente: O usuário autenticado no ambiente da detentora não é o mesmo usuário autenticado no ambiente da iniciadora e que criou o consentimento. (AUTENTICACAO _DIVERGENTE);  
 
     3. **Demais validações executadas durante o processamento assíncrono do consentimento pela detentora, poderão ser consultados pela iniciadora através dos endpoints GET /recurring-consents/{recurringConsentId} previstos com retorno HTTP Code 200 - OK com status REVOKED e revocationReason conforme abaixo (detalhamento adicional na documentação técnica da API).**  
       3.1 **Demais validações durante o processamento assíncrono:**  
@@ -119,10 +117,10 @@ info:
           &emsp;4.2.2.11 Limite valor excedido por período: Foi atingido o valor limite permitido pelo usuário por um determinado período de tempo no consentimento do pagamento (LIMITE_PERIODO_VALOR_EXCEDIDO);  
           &emsp;4.2.2.12 Limite quantidade excedida por período: A quantidade de cobranças atingiu o limite determinado pelo usuário na criação do consentimento (LIMITE_PERIODO_QUANTIDADE_EXCEDIDO);   
           &emsp;4.2.2.13 Consentimento pendente de autorização: Consentimento em “PARTIALLY_ACCEPTED” aguardando aprovação de múltiplas alçadas (CONSENTIMENTO_PENDENTE_AUTORIZACAO);  
-          &emsp;4.2.2.14 Limite global excedido: O consentimento encontra-se autorizado e o valor solicitado para cobrança ultrapassa a faixa de limite global parametrizado pelo usuário durante a criação do consentimento (LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO);
+          &emsp;4.2.2.14 Limite global excedido: O consentimento encontra-se autorizado e o valor solicitado para cobrança ultrapassa a faixa de limite global parametrizado pelo usuário durante a criação do consentimento (LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO);  
           &emsp;4.2.2.15 Limite de transação excedido: O consentimento encontra-se autorizado e o valor solicitado para cobrança ultrapassa a faixa de limite de valor por transação parametrizado pelo usuário na criação do consentimento (LIMITE_VALOR_TRANSACAO_CONSENTIMENTO_EXCEDIDO);  
           &emsp;4.2.2.16 Limite de retentativas atingido: Valida se todas as tentativas de liquidação permitidas já foram realizadas (LIMITE_TENTATIVA_EXCEDIDO);  
-          &emsp;4.2.2.17 Fora do prazo permitido: A tentativa de agendamento foi realizada fora do horário ou período permitido e não pode ser aceita pela instituição detentora (FORA_PRAZO_PERMITIDO).
+          &emsp;4.2.2.17 Fora do prazo permitido: A tentativa de agendamento foi realizada fora do horário ou período permitido e não pode ser aceita pela instituição detentora (FORA_PRAZO_PERMITIDO).  
 
     5. **Validações na consulta do pagamento (_GET /pix/recurring-payments/{recurringPaymentId}_ e _GET /pix/recurring-payments_)**  
       5.1 **Casos de erro relacionados às permissões de segurança para acesso à API (ex. certificado, access_token)**  
@@ -2366,10 +2364,8 @@ components:
             - REJEITADO_USUARIO
             - CONTAS_ORIGEM_DESTINO_IGUAIS
             - CONTA_NAO_PERMITE_PAGAMENTO
-            - SALDO_INSUFICIENTE
-            - VALOR_ACIMA_LIMITE
             - AUTENTICACAO_DIVERGENTE
-          example: VALOR_ACIMA_LIMITE
+          example: AUTENTICACAO_DIVERGENTE
           description: |
             Código indicador do motivo de rejeição.
             - NAO_INFORMADO
@@ -2378,8 +2374,6 @@ components:
             - REJEITADO_USUARIO
             - CONTAS_ORIGEM_DESTINO_IGUAIS
             - CONTA_NAO_PERMITE_PAGAMENTO
-            - SALDO_INSUFICIENTE
-            - VALOR_ACIMA_LIMITE
             - AUTENTICACAO_DIVERGENTE
         detail:
           type: string
@@ -2393,8 +2387,6 @@ components:
             - REJEITADO_USUARIO: O usuário rejeitou a autorização do consentimento;
             - CONTAS_ORIGEM_DESTINO_IGUAIS: A conta selecionada é igual à conta destino e não permite realizar esse pagamento;
             - CONTA_NAO_PERMITE_PAGAMENTO: A conta selecionada é do tipo [salario/investimento/liquidação/outros] e não permite realizar esse pagamento;
-            - SALDO_INSUFICIENTE: A conta selecionada não possui saldo suficiente para realizar o pagamento;
-            - VALOR_ACIMA_LIMITE: O valor ultrapassa o limite estabelecido para permitir a realização de transações pelo cliente;
             - AUTENTICACAO_DIVERGENTE : Usuário autenticado no detentor diverge do usuário autenticado no iniciador;
           example: O usuário rejeitou a autorização do consentimento 
     RejectionReasonGet:


### PR DESCRIPTION
### Contexto

Durante as análises conduzidas pela DTO, foi identificado que os erros SALDO_INSUFICIENTE e VALOR_ACIMA_LIMITE não devem ser retornados no momento do consentimento para a API Pagamentos automáticos ▪ Isso ocorre devido à impossibilidade de prever o pagamento que será efetuado posteriormente, uma vez que o consentimento para pagamentos automáticos apenas estabelece barreiras de cobrança, as quais deverão ser validadas no momento da transação – Dessa forma, GT e DTO concordam em remover os erros mencionados do consentimento, mantendo-os apenas para o momento do pagamento


### Descrição

▪ No header da API Pagamentos automáticos, remover os itens 2.1.6 e 2.1.7
▪ Na resposta de sucesso dos endpoints POST /recurring-consents, GET /recurring-
consents/{recurringConsentId} e PATCH /recurring-consents/{recurringConsentId}:
– No ENUM /data/rejection/reason/code, remover do domínio os valores SALDO_INSUFICIENTE
e VALOR_ACIMA_LIMITE
– No campo/data/rejection/reason/detail, remover da descrição as seguintes entradas:
▫ SALDO_INSUFICIENTE: A conta selecionada não possui saldo suficiente para realizar o
pagamento;
▫ VALOR_ACIMA_LIMITE: O valor ultrapassa o limite estabelecido para permitir a realização de
transações pelo cliente