### PR TITLE
[GT de Serviços] PSV-362 - Automatic Payments - v2.2.0-rc.1: API Pagamentos Automáticos – Proposta para ajustar a descrição do objeto que detém as informações do devedor do contrato

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2855,7 +2855,7 @@ components:
               example: '2023-05-21'
     ContractDebtor:
       type: object
-      description: Informações sobre o cliente devedor do contrato.
+      description:  Informações sobre o cliente devedor do contrato. Pode possuir titularidade diferente do usuário pagador descrito nos objetos "/data/loggedUser" e "/data/businessEntity".
       required: 
         - name
         - document


### PR DESCRIPTION
### Contexto

Durante o piloto da API
Pagamentos Automáticos,
surgiram questionamentos
quanto à necessidade do
devedor do contrato ser,
obrigatoriamente, o mesmo
usuário logado na instituição
iniciadora
– Assim, GT e DTO entendem
necessário esclarecer o
comportamento esperado, a
fim de evitar novas dúvidas
futuras sobre o assunto

### Descrição

Ajustar a descrição do objeto /data/recurringConfiguration/automatic/contractDebtor
nos endpoints POST /recurring-consents (Request e Response 201), GET /recurring
consents/{recurringConsentId} (Response 200) e PATCH /recurring-
consents/{recurringConsentId} (Response 200):
– De: Informações sobre o cliente devedor do contrato.
– Para: Informações sobre o cliente devedor do contrato. Pode possuir titularidade
diferente do usuário pagador descrito nos objetos "/data/loggedUser" e
"/data/businessEntity"