### PR TITLE
[GT de Serviços] PSV-368 - Automatic Payments - v2.2.0-rc.1: API Pagamentos Automáticos – Proposta para ajustar a descrição do campo que contempla a data de início dos ciclos de cobrança

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2759,8 +2759,7 @@ components:
               format: date
               pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
               description: |
-                Representa a data prevista para a primeira ocorrência de um pagamento associado a recorrência. 
-                Uma string com data e hora conforme especificação [RFC-3339](https://datatracker.ietf.org/doc/html/rfc3339), sempre com a utilização de timezone UTC(UTC time format).
+                Representa a data prevista para o início do ciclo de cobrança dos pagamentos associados à recorrência. Trata-se de uma string com data conforme especificação RFC-3339, seguindo o horário de Brasília (UTC-3). O pagamento inicial avulso, declarado no objeto firstPayment do consentimento, não está sujeito a essa data.
               example: '2023-05-21'
     Automatic:
       type: object
@@ -2850,8 +2849,7 @@ components:
               format: date
               pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
               description: |
-                Representa a data prevista para a primeira ocorrência de um pagamento associado a recorrência. 
-                Uma string com data e hora conforme especificação [RFC-3339](https://datatracker.ietf.org/doc/html/rfc3339), sempre com a utilização de timezone UTC(UTC time format).
+                Representa a data prevista para o início do ciclo de cobrança dos pagamentos associados à recorrência. Trata-se de uma string com data conforme especificação RFC-3339, seguindo o horário de Brasília (UTC-3). O pagamento inicial avulso, declarado no objeto firstPayment do consentimento, não está sujeito a essa data.
               example: '2023-05-21'
     ContractDebtor:
       type: object


### PR DESCRIPTION
### Contexto 

A descrição atual do
campo
referenceStartDate não
reflete com precisão seu
funcionamento na
prática, uma vez que,
neste produto, não é
possível determinar com
exatidão a data em que o
recebedor enviará a
cobrança
– Dessa forma, GT e
DTO consideram
necessário ajustar a
descrição do campo, a
fim de corrigir o
significado da
informação presente
na especificação

### Descrição

Na mensagem de requisição do endpoint POST /recurring-consents e nas mensagens de resposta
de sucesso dos endpoints POST /recurring-consents, GET /recurring-
consents/{recurringConsentId} e PATCH /recurring-consents/{recurringConsentId}:
– Ajustar a descrição do campo /data/recurringConfiguration/automatic/referenceStartDate:
▫ De:
Representa a data prevista para a primeira ocorrência de um pagamento associado a
recorrência. Uma string com data e hora conforme especificação RFC-3339, sempre com a
utilização de timezone UTC (UTC time format)
▫ Para:
Representa a data prevista para o início do ciclo de cobrança dos pagamentos associados à
recorrência. Trata-se de uma string com data conforme especificação RFC-3339, seguindo o
horário de Brasília (UTC-3). O pagamento inicial avulso, declarado no objeto firstPayment
do consentimento, não está sujeito a essa data
