### PR TITLE
[GT de Serviços] PSV-372 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para remover o objeto de sinais de risco da consulta do consentimento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3858,8 +3858,6 @@ components:
                       example: O usuário rejeitou a autorização do consentimento 
             recurringConfiguration:
               $ref: '#/components/schemas/RecurringConfiguration'
-            riskSignals:
-              $ref: '#/components/schemas/RiskSignalsConsents'
             authorisedAtDateTime:
               type: string
               format: date-time
@@ -4121,8 +4119,6 @@ components:
                       example: O usuário rejeitou a autorização do consentimento 
             recurringConfiguration:
               $ref: '#/components/schemas/RecurringConfiguration'
-            riskSignals:
-              $ref: '#/components/schemas/RiskSignalsConsents'
             authorisedAtDateTime:
               type: string
               format: date-time


### PR DESCRIPTION
### Contexto

▪ Com o objetivo de simplificar o   payload da API de consulta de   consentimentos, a DTO propõe a   remoção dos campos relacionados   aos sinais de risco do corpo de   resposta dos endpoints  correspondentes  
▪ Tais campos têm como finalidade   apenas auxiliar o detentor na   tomada de decisão quanto à   aceitação da transação. Além   disso, são informados diretamente   pelo ITP e não possuem valor   semântico para o recurso em   questão  

### Definição

Nas mensagens de resposta de sucesso dos endpoints GET /recurring-consents/{recurringConsentId} e PATCH /recurring-consents/{recurringConsentId}:  
– Remover o objeto /data/riskSignals