### PR TITLE
[GT de Serviços] PSV-373 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para adicionar restrição ao método de liquidação AUTO para Transferências Inteligentes

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -194,7 +194,7 @@ info:
     Não é permitido ao usuário pagador o cancelamento de uma nova tentativa de pagamento, realizada pelo recebedor, quando autorizado no consentimento (campo “/data/recurringConfiguration/automatic/isRetryAccepted” como “True”) pelo usuário pagador ou quando o Iniciador precisar enviar um novo endToEndId. 
     Aplica-se tanto para a tentativa intradia quanto para a tentativa em dias subsequentes. É permitido ao recebedor o cancelamento das novas tentativas em dias subsequentes. Aplicam-se as regras de cancelamento da tentativa original, conforme previsto na descrição do endpoint PATCH /pix/recurringPayments Pagamentos que são novas tentativas, intradia ou em dias subsequentes, podem ser identificados pela presença do campo “/data/originalRecurringPaymentId” no recurso. 
   
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -706,8 +706,8 @@ components:
         - AUTO - Indica o pagamento de uma recorrência de Pix automático, onde o consentimento foi previamente autorizado pelo pagador e o pagamento é realizado automaticamente pelo Iniciador de Pagamentos sob comando do recebedor.
 
         [Restrição]  
-        Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar uma recorrência (valor do campo "/data/paymentReferente" diferente de "zero"), apenas o método AUTO é permitido, ou;  
-        Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar o pagamento inicial avulso (valor do campo "/data/paymentReferente" igual a "zero"), apenas o método MANU é permitido.  
+        Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar uma recorrência (valor do campo "/data/paymentReference" diferente de "zero"), apenas o método AUTO é permitido, ou;  
+        Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar o pagamento inicial avulso (valor do campo "/data/paymentReference" igual a "zero"), apenas o método MANU é permitido.  
         Para consentimentos de Transferências Inteligentes (objeto “sweeping” selecionado no “oneOf” do campo “/data/recurringConfiguration/”), apenas os métodos MANU, DICT e INIC são permitidos.
       enum:
         - MANU


### PR DESCRIPTION
### Contexto

Em conformidade com a IN 614, foi adicionado à API um novo instrumento de liquidação, AUTO 

▪ Esse instrumento é exclusivo do Pix Automático e, portanto, deve haver um tratamento específico que impeça sua utilização em produtos que não sejam desse tipo 

– Diante disso, o GT e a DTO concordam quanto à necessidade de ajuste na especificação, a fim de refletir esse impeditivo técnico

### Descrição

Descrição da proposta

▪ Na mensagem de requisição e resposta de sucesso do endpoint POST /pix/recurring-payments e na mensagem de resposta de sucesso dos endpoints GET /pix/recurring-payments/{recurringPaymentId} e PATCH /pix/recurringpayments/{recurringPaymentId}:

 – Alterar a restrição presente no campo /data/localInstrument: 

▫ De: Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar uma recorrência (valor do campo "/data/paymentReference" diferente de "zero"), apenas o método AUTO é permitido, ou; Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar o pagamento inicial avulso (valor do campo "/data/paymentReference" igual a "zero"), apenas o método MANU é permitido

 ▫ Para: Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar uma recorrência (valor do campo "/data/paymentReference" diferente de "zero"), apenas o método AUTO é permitido, ou; Caso consentimento associado a tentativa de pagamento seja para Pix automático (objeto “automatic” selecionado no oneOf do campo "/data/recurringConfiguration") e a referência do pagamento indicar o pagamento inicial avulso (valor do campo "/data/paymentReference" igual a "zero"), apenas o método MANU é permitido. Para consentimentos de Transferências Inteligentes (objeto “sweeping” selecionado no “oneOf” do campo “/data/recurringConfiguration/”), apenas os métodos MANU, DICT e INIC são permitidos