### PR TITLE
[GT de Serviços] PSV-376 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para ajustar os códigos de erro síncronos na criação do pagamento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -194,7 +194,7 @@ info:
     Não é permitido ao usuário pagador o cancelamento de uma nova tentativa de pagamento, realizada pelo recebedor, quando autorizado no consentimento (campo “/data/recurringConfiguration/automatic/isRetryAccepted” como “True”) pelo usuário pagador ou quando o Iniciador precisar enviar um novo endToEndId. 
     Aplica-se tanto para a tentativa intradia quanto para a tentativa em dias subsequentes. É permitido ao recebedor o cancelamento das novas tentativas em dias subsequentes. Aplicam-se as regras de cancelamento da tentativa original, conforme previsto na descrição do endpoint PATCH /pix/recurringPayments Pagamentos que são novas tentativas, intradia ou em dias subsequentes, podem ser identificados pela presença do campo “/data/originalRecurringPaymentId” no recurso. 
   
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto

▪ Durante o atendimento ao ticket #94204 pelo GT, foi identificado um ajuste necessário em um dos erros síncronos da API  
▪ No processo de elaboração da proposta para contemplar esse ajuste, DTO identificou a necessidade de exclusão do erro DETALHE_TENTATIVA_INV ALIDO do conjunto de erros do endpoint em questão, uma vez que a lógica para novas tentativas foi transferida para outro endpoint  

### Descrição

▪ Na mensagem de resposta HTTP 422 do endpoint POST /pix/recurring-payments: Serviços  
– No ENUM errors.code:  
▫ Remover do domínio o valor DETALHE_TENTATIVA_INVALIDA  
▫ Remover da descrição do campo a menção ao erro DETALHE_TENTATIVA_INVALIDA  
▫ Alterar a descrição associada ao item VALOR_INVALIDO:  
- De: O valor enviado não é válido para o QR Code informado  
- Para: O valor enviado não é válido para o consentimento associado ao pagamento  
– Nos campos errors.detail e errors.title:  
▫ Remover da descrição do campo a menção ao erro DETALHE_TENTATIVA_INVALIDA  
▫ Alterar a descrição associada ao item VALOR_INVALIDO:  
- De: O valor enviado não é válido para o QR Code informado  
- Para: O valor enviado não é válido para o consentimento associado ao pagamento  