### PR TITLE
[GT de Serviços] PSV-377 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para alterar a descrição dos campos que recebem o nome do recebedor, o valor máximo e o prazo de expiração na edição do consentimento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -194,7 +194,7 @@ info:
     Não é permitido ao usuário pagador o cancelamento de uma nova tentativa de pagamento, realizada pelo recebedor, quando autorizado no consentimento (campo “/data/recurringConfiguration/automatic/isRetryAccepted” como “True”) pelo usuário pagador ou quando o Iniciador precisar enviar um novo endToEndId. 
     Aplica-se tanto para a tentativa intradia quanto para a tentativa em dias subsequentes. É permitido ao recebedor o cancelamento das novas tentativas em dias subsequentes. Aplicam-se as regras de cancelamento da tentativa original, conforme previsto na descrição do endpoint PATCH /pix/recurringPayments Pagamentos que são novas tentativas, intradia ou em dias subsequentes, podem ser identificados pela presença do campo “/data/originalRecurringPaymentId” no recurso. 
   
-  version: 2.2.0-rc.1
+  version: 2.2.0-rc.2
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
### Contexto

▪ Durante o atendimento do ticket #94204 pelo GT, foi identificado um ajuste necessário na descrição do campo que representa o nome do recebedor durante a edição do consentimento – A descrição deve esclarecer que, caso apenas esse campo seja informado, nenhum outro dado deverá ser atualizado  
▪ Com o objetivo de reduzir eventuais dúvidas por parte dos consumidores, entende-se necessário revisar as descrições dos campos relacionados ao prazo de expiração do consentimento e ao valor máximo por transação  

### Descrição

– Ajustar a descrição do campo “/data/expirationDateTime”: 
▫ De: Data e hora em que o consentimento deve deixar de ser válido. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).  
[Restrição] Caso esse campo não seja enviado, a instituição detentora deve considerar a   
extensão do prazo para um período indeterminado; ou;  
Caso enviado, esse campo deve ser, no mínimo, D, sendo D o dia da requisição e o horário deve ser às 23:59:59 (UTC)  
▫ Para: Data e hora em que o consentimento deve deixar de ser válido. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC (UTC time format).  
[Restrição] Caso esse campo não seja enviado, a instituição detentora deve considerar a extensão do prazo para um período indeterminado, exceto em casos de edição exclusiva do campo “/data/creditors/name”; ou;  
Caso enviado, esse campo deve ser, no mínimo, D, sendo D o dia da requisição e o horário deve ser às 23:59:59 (UTC)  