### PR TITLE
[GT de Serviços] PSV-378 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para remover o objeto contendo as informações do cancelamento do pagamento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4467,8 +4467,6 @@ components:
           $ref: '#/components/schemas/CreditorAccountPostPixPaymentsResponse'
         debtorAccount:
             $ref: '#/components/schemas/DebtorAccount'
-        cancellation:
-          $ref: '#/components/schemas/PixPaymentCancellation'
         authorisationFlow:
           type: string
           enum:


### PR DESCRIPTION
### Contexto

Considerando que o cancelamento de um pagamento só pode ocorrer após sua aceitação, e mediante solicitação expressa do pagador ou do recebedor (no caso de Pix Automático), não é possível que a instituição retorne esse item na resposta à criação do pagamento. Portanto, sua presença na resposta não se faz necessária  

### Definição

Na mensagem de resposta de sucesso do endpoint POST /pix/recurring-payments: 
– Remover o objeto /data/cancellation  