### PR TITLE
[GT de Serviços] PSV-383 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para remover parâmetros de novas tentativas do endpoint de criação de pagamentos

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -934,7 +934,6 @@ components:
                   - LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO
                   - LIMITE_VALOR_TRANSACAO_CONSENTIMENTO_EXCEDIDO
                   - FORA_PRAZO_PERMITIDO
-                  - DETALHE_TENTATIVA_INVALIDO
                 example: SALDO_INSUFICIENTE
                 description: |
                   Códigos de erros previstos na criação da iniciação de pagamento:
@@ -956,7 +955,6 @@ components:
                   - LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO: Limite total excedido
                   - LIMITE_VALOR_TRANSACAO_CONSENTIMENTO_EXCEDIDO: O valor da transação ultrapassar o limite de valor por transação.
                   - FORA_PRAZO_PERMITIDO: O horário ou período da requisição não permite o agendamento pelo detentor.
-                  - DETALHE_TENTATIVA_INVALIDO: O parâmetro [nome_do(s)_campo(s)] inseridos para a nova tentativa de pagamento não condizem com o pagamento original que falhou e não são permitidos na nova tentativa de pagamento.
               title:
                 type: string
                 maxLength: 255
@@ -982,7 +980,6 @@ components:
                   - LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO: Limite total excedido
                   - LIMITE_VALOR_TRANSACAO_CONSENTIMENTO_EXCEDIDO: Limite de transação excedido.
                   - FORA_PRAZO_PERMITIDO: Tentativa fora do prazo.
-                  - DETALHE_TENTATIVA_INVALIDO: Nova tentativa inválida
               detail:
                 type: string
                 maxLength: 2048
@@ -1007,9 +1004,7 @@ components:
                   - ERRO_IDEMPOTENCIA: Erro idempotência.
                   - LIMITE_VALOR_TOTAL_CONSENTIMENTO_EXCEDIDO: O valor da transação excede o limite global do consentimento.
                   - LIMITE_VALOR_TRANSACAO_CONSENTIMENTO_EXCEDIDO: O valor da transação ultrapassar o limite de valor por transação.
-                  - LIMITE_TENTATIVAS_EXCEDIDO: O limite de tentativas para liquidação do pagamento permitidas pelo arranjo foi excedido.
                   - FORA_PRAZO_PERMITIDO: O horário ou período da requisição não permite o agendamento pelo detentor.
-                  - DETALHE_TENTATIVA_INVALIDO: O parâmetro [nome_do(s)_campo(s)] inseridos para a nova tentativa de pagamento não condizem com o pagamento original que falhou e não são permitidos na nova tentativa de pagamento.
         meta:
           $ref: '#/components/schemas/Meta'
     422ResponseErrorCreateRecurringPaymentsPaymentId:


### PR DESCRIPTION
### Contexto
▪ O mecanismo de novas   
tentativas de liquidação de   
um pagamento original que   
falhou foi migrado para um   
endpoint específico,   
dedicado exclusivamente a   
esse fim  
– Em decorrência dessa   
alteração, torna-se   
necessário remover do   
endpoint de criação de   
pagamentos os   
parâmetros   
anteriormente   
utilizados para tratar   
essas tentativas, uma   
vez que tais elementos   
passam a ser exclusivos   
do novo endpoint  


### Descrição


▪ Remover o campo /data/originalRecurringPaymentId da mensagem de requisição e resposta de sucesso Serviços  
do endpoint POST /pix/recurring-payments  
▪ Na resposta de erro 422 do endpoint POST /pix/recurring-payments, realizar os seguintes ajustes:  
– Na descrição dos campos errors.code, errors.detail e erros.title, remover menção aos erros:  
▫ DETALHE_TENTATIVA_INVALIDO  
▫ LIMITE_TENTATIVAS_EXCEDIDO  
– Remover os seguintes valores do enum errors.code:  
▫ DETALHE_TENTATIVA_INVALIDO  
▫ LIMITE_TENTATIVAS_EXCEDIDO  