### PR TITLE
[GT de Serviços] PSV-384 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para adicionar motivo de rejeição para tentativa de autorização do consentimento de Transferências Inteligentes via JSR

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -83,6 +83,7 @@ info:
         &ensp;2.1.4 Mesma conta origem/destino: A conta indicada pelo usuário para recebimento é a mesma selecionada para o pagamento (CONTAS_ORIGEM_DESTINO_IGUAIS);  
         &ensp;2.1.5 Tipo de conta inválida: A conta indicada não permite operações de pagamento (CONTA_NAO_PERMITE_PAGAMENTO);  
         &ensp;2.1.6 Autenticação divergente: O usuário autenticado no ambiente da detentora não é o mesmo usuário autenticado no ambiente da iniciadora e que criou o consentimento. (AUTENTICACAO _DIVERGENTE);  
+        &ensp;2.1.7 O consentimento está configurado para um produto ainda não suportado pela Jornada sem Redirecionamento (FLUXO_NAO_SUPORTADO_PRODUTO).
 
     3. **Demais validações executadas durante o processamento assíncrono do consentimento pela detentora, poderão ser consultados pela iniciadora através dos endpoints GET /recurring-consents/{recurringConsentId} previstos com retorno HTTP Code 200 - OK com status REVOKED e revocationReason conforme abaixo (detalhamento adicional na documentação técnica da API).**  
       3.1 **Demais validações durante o processamento assíncrono:**  
@@ -2458,6 +2459,7 @@ components:
             - CONTAS_ORIGEM_DESTINO_IGUAIS
             - CONTA_NAO_PERMITE_PAGAMENTO
             - AUTENTICACAO_DIVERGENTE
+            - FLUXO_NAO_SUPORTADO_PRODUTO
           example: AUTENTICACAO_DIVERGENTE
           description: |
             Código indicador do motivo de rejeição.
@@ -2468,6 +2470,7 @@ components:
             - CONTAS_ORIGEM_DESTINO_IGUAIS
             - CONTA_NAO_PERMITE_PAGAMENTO
             - AUTENTICACAO_DIVERGENTE
+            - FLUXO_NAO_SUPORTADO_PRODUTO
         detail:
           type: string
           pattern: '[\w\W\s]*'
@@ -2481,6 +2484,7 @@ components:
             - CONTAS_ORIGEM_DESTINO_IGUAIS: A conta selecionada é igual à conta destino e não permite realizar esse pagamento;
             - CONTA_NAO_PERMITE_PAGAMENTO: A conta selecionada é do tipo [salario/investimento/liquidação/outros] e não permite realizar esse pagamento;
             - AUTENTICACAO_DIVERGENTE : Usuário autenticado no detentor diverge do usuário autenticado no iniciador;
+            - FLUXO_NAO_SUPORTADO_PRODUTO: O consentimento está configurado para um produto ainda não suportado pela Jornada sem Redirecionamento.
           example: O usuário rejeitou a autorização do consentimento 
     RejectionReasonGet:
       type: object


### PR DESCRIPTION
### Contexto

Para alinhar o fluxo de autorização da API Pagamentos sem Redirecionamento (JSR) com as regras de negócio, a proposta é criar um erro representativo. A API de Pagamentos Automáticos gerencia dois produtos — Pix Automático e Transferências Inteligentes. No entanto, a autorização de consentimento via dispositivo vinculado será suportada somente pelo Pix Automático.

Dessa forma, a implementação de uma mensagem de erro específica se faz necessária para guiar o usuário em caso de tentativa de autorizar um consentimento de Transferências Inteligentes através desse novo fluxo

### Descrição

Na mensagem de resposta de sucesso dos endpoints POST /recurring-consents, GET /recurring-consents/{recurringConsentId} e PATCH /recurring-consents/{recurringConsentId}:

No ENUM /data/rejection/reason/code, adicionar um novo valor ao domínio:

FLUXO_NAO_SUPORTADO_PRODUTO

Na descrição do ENUM /data/rejection/reason/code, adicionar a seguinte entrada abaixo dos demais itens:

FLUXO_NAO_SUPORTADO_PRODUTO

Na descrição dos campos /data/rejection/reason/detail adicionar a seguinte entrada abaixo dos demais itens:

FLUXO_NAO_SUPORTADO_PRODUTO: O consentimento está configurado para um produto ainda não suportado pela Jornada sem Redirecionamento.

No header da API, adicionar um novo item ao tópico 2, item 2.1.7:

2.1.7 O consentimento está configurado para um produto ainda não suportado pela Jornada sem Redirecionamento (FLUXO_NAO_SUPORTADO_PRODUTO).