### PR TITLE
[GT de Serviços] PSV-385 - Automatic Payments - v2.2.0-rc.2: API Pagamentos automáticos – Proposta para alterar a descrição do campo que recebe o identificador do contrato do pagador no ambiente do recebedor

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2783,7 +2783,8 @@ components:
               minLength: 1
               maxLength: 35
               example: XE00038166201907261559y6j6
-              description: Identificador do contrato de transação
+              description: |
+                Identificador do contrato do cliente localizado no ambiente do recebedor. Essa informação pode ser fornecida pelo recebedor ou gerada pela ITP durante a criação do consentimento (se previsto em acordo com o recebedor).
             fixedAmount:
               type: string
               pattern: '^((\d{1,16}\.\d{2}))$'
@@ -2868,7 +2869,8 @@ components:
               minLength: 1
               maxLength: 35
               example: XE00038166201907261559y6j6
-              description: Identificador do contrato de transação
+              description: |
+                Identificador do contrato do cliente localizado no ambiente do recebedor. Essa informação pode ser fornecida pelo recebedor ou gerada pela ITP durante a criação do consentimento (se previsto em acordo com o recebedor).
             fixedAmount:
               type: string
               pattern: '^((\d{1,16}\.\d{2}))$'


### PR DESCRIPTION
### Contexto

Durante o atendimento do ticket #101674, GT e DTO identificaram a necessidade de aprimorar a descrição do campo contractId, pois a informação atual é insuficiente para esclarecer seu significado e modo de operação

### Descrição

Na mensagem de requisição do endpoint POST /recurring-consents e nas mensagens de resposta Serviços
de sucesso dos endpoints POST /recurring-consents, GET /recurringconsents/{recurringConsentId} e PATCH /recurring-consents/{recurringConsentId}:
– Ajustar a descrição do campo /data/recurringConfiguration/automatic/contractId:
▫ De:
Identificador do contrato de transação.
▫ Para:
Identificador do contrato do cliente localizado no ambiente do recebedor. Essa informação
pode ser fornecida pelo recebedor ou gerada pela ITP durante a criação do consentimento (se
previsto em acordo com o recebedor).